### PR TITLE
Only switch windows if a choice has actually been made

### DIFF
--- a/choosem/cli/focus.py
+++ b/choosem/cli/focus.py
@@ -6,6 +6,7 @@ import click
 from choosem.utils import choose
 
 
+
 @click.command()
 def focus():
     """focus a program window"""
@@ -14,5 +15,6 @@ def focus():
         capture_output=True).stdout.decode()
     windows = json.loads(windows)
     choice = choose('\n'.join([f"{w['app']}: {w['title']}" for w in windows if w.get('title')]), index=True)
-    choice = windows[choice]
-    subprocess.run(['yabai', '-m', 'window', '--focus', str(choice["id"])])
+    if choice != -1:
+        choice = windows[choice]
+        subprocess.run(['yabai', '-m', 'window', '--focus', str(choice["id"])])


### PR DESCRIPTION
Hi,

I am not sure if you are still doing work on this lib, but I am proposing a simple fix. When no choice has been made (i.e. the user presses ESC instead of selecting an option), the choice evaluates to `-1`, but since we can index arrays with negative ints inin Python this means that `windows[-1]` will be evaluated and switch to the last window in that array. I am proposing a simple check here to work around that. Thanks.